### PR TITLE
Remove email from AuthResponse

### DIFF
--- a/src/main/java/event_scheduler_api/dto/response/AuthResponse.java
+++ b/src/main/java/event_scheduler_api/dto/response/AuthResponse.java
@@ -7,5 +7,4 @@ import lombok.Value;
 @Builder
 public class AuthResponse {
     String token;
-    String email;
 }

--- a/src/main/java/event_scheduler_api/service/AuthService.java
+++ b/src/main/java/event_scheduler_api/service/AuthService.java
@@ -35,7 +35,7 @@ public class AuthService {
 
         String token = this.jwtUtil.generateToken(request.getEmail());
 
-        return AuthResponse.builder().token(token).email(user.getEmail()).build();
+        return AuthResponse.builder().token(token).build();
     }
 
     public AuthResponse loginUser(LoginRequest request) throws Exception {
@@ -46,10 +46,11 @@ public class AuthService {
                 )
         );
 
-        User user = this.userRepository.findByEmail(request.getEmail()).orElseThrow(() -> new Exception("User with email not found!"));
+        // Check that user exists 
+        this.userRepository.findByEmail(request.getEmail()).orElseThrow(() -> new Exception("User with email not found!"));
 
         String token = this.jwtUtil.generateToken(request.getEmail());
 
-        return AuthResponse.builder().token(token).email(user.getEmail()).build();
+        return AuthResponse.builder().token(token).build();
     }
 }


### PR DESCRIPTION
### Changes
- removed `email` from `AuthResponse`
  - client doesn't doesn't need `email` field and can make requests using the given `token`